### PR TITLE
Fix meiji build fail

### DIFF
--- a/consequences/src/solvers/algorithms/Meiji/dockerfile
+++ b/consequences/src/solvers/algorithms/Meiji/dockerfile
@@ -3,9 +3,9 @@ FROM openjdk:jre-slim
 LABEL pace=true
 WORKDIR /
 ADD run.sh /run.sh
-RUN apt-get update
-RUN apt-get -y install debian-keyring debian-archive-keyring
-RUN apt-get update && apt-get install -y git make openjdk-11-jdk
-RUN git clone https://github.com/TCS-Meiji/PACE2017-TrackA.git
-RUN javac PACE2017-TrackA/tw/exact/*.java
-RUN chmod +x run.sh
+RUN apt-get update && \
+    apt-get -y install debian-keyring debian-archive-keyring
+RUN apt-get update && apt-get install -y git make openjdk-11-jdk && \
+    git clone https://github.com/TCS-Meiji/PACE2017-TrackA.git && \
+    javac PACE2017-TrackA/tw/exact/*.java && \
+    chmod +x run.sh

--- a/consequences/src/solvers/algorithms/Meiji/dockerfile
+++ b/consequences/src/solvers/algorithms/Meiji/dockerfile
@@ -1,9 +1,11 @@
 #Use official debian slim docker image
-FROM openjdk:10-jre-slim
+FROM openjdk:jre-slim
 LABEL pace=true
 WORKDIR /
 ADD run.sh /run.sh
-RUN apt-get update && apt-get install -y git make openjdk-10-jdk && \
-    git clone https://github.com/TCS-Meiji/PACE2017-TrackA.git && \
-    javac PACE2017-TrackA/tw/exact/*.java && \
-    chmod +x run.sh
+RUN apt-get update
+RUN apt-get -y install debian-keyring debian-archive-keyring
+RUN apt-get update && apt-get install -y git make openjdk-11-jdk
+RUN git clone https://github.com/TCS-Meiji/PACE2017-TrackA.git
+RUN javac PACE2017-TrackA/tw/exact/*.java
+RUN chmod +x run.sh

--- a/consequences/src/solvers/algorithms/Meiji/dockerfile
+++ b/consequences/src/solvers/algorithms/Meiji/dockerfile
@@ -1,5 +1,5 @@
 #Use official debian slim docker image
-FROM openjdk:jre-slim
+FROM openjdk:11-jre-slim
 LABEL pace=true
 WORKDIR /
 ADD run.sh /run.sh


### PR DESCRIPTION
The meiji solver was failing to build due to missing public key values (presumably due to an old base image). This PR bumps the version of the base image and adds commands to set up the missing public keys.